### PR TITLE
ENG-42438 Update Tekh Version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ outputs:
     description: Commit message generated from version change
 runs:
   using: 'docker'
-  image: docker://public.ecr.aws/skedulo/tekh:v0.7.8-4-g305b2ce
+  image: docker://public.ecr.aws/skedulo/tekh:v0.8.0-2-g9029bdc
   entrypoint: /action.sh
   args:
     - ${{ inputs.working_directory }}


### PR DESCRIPTION
Update to the new version of [tekh](https://github.com/Skedulo/tekh/releases/tag/v0.8.1) to support exit codes