### PR TITLE
ENG-52441 Support App Version Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This action updates a tekh repository to latest version
 * `working_directory` - path in which to run tekh - defaults to /github/workspace
 * `version_label` - label to look at to determine chart version - defaults to
   `helm.sh/chart`
+* `app_version_label` - label to look at to determine app version - defaults to
+  `app.kubernetes.io/version`
 
 ## Outputs
 
@@ -33,6 +35,9 @@ The version of helm after running tekh
 ## `changed`
 
 Whether the version has changed
+
+## `app_version`
+The version of the application after running tekh
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,13 @@ inputs:
     description: >
       Label to look for helm chart version
     default: "helm.sh/chart"
+  app_version_label:
+    description: >
+      Label to look for internal application version
+    default: "app.kubernetes.io/version"
 outputs:
+  app_version:
+    description: Chart version of upgrade
   version:
     description: Chart version of upgrade
   changed:
@@ -66,7 +72,7 @@ outputs:
     description: Commit message generated from version change
 runs:
   using: 'docker'
-  image: docker://public.ecr.aws/skedulo/tekh:v0.8.1-10-g5b44a4d
+  image: docker://public.ecr.aws/skedulo/tekh:v0.8.2-2-gd450b41
   entrypoint: /action.sh
   args:
     - ${{ inputs.working_directory }}
@@ -82,3 +88,4 @@ runs:
     - ${{ inputs.custom_image_name }}
     - ${{ inputs.version }}
     - ${{ inputs.version_label }}
+    - ${{ inputs.app_version_label }}


### PR DESCRIPTION
This requires https://github.com/Skedulo/tekh/pull/16 to be build & published before we can merge it. The main reason for this is so that we can collect release notes for the internal app version, as well as the helm chart depending what is desired. Actual release note collection will still occur in the [github-actions](https://github.com/Skedulo/github-actions/blob/v1/.github/workflows/helm-updater.yml) project 